### PR TITLE
[New Feature] Add TopicTransfer CRD for Topic Transfer Feature with Atomicity 

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,3 +374,8 @@ $ ./remove-storage-class.sh
 ```
 
 > Note: the NFS persistence data will not be deleted by default.
+
+
+```kubectl apply -f rocketmq-operator.yaml```
+
+```kubectl apply -f rocketmq-cluster.yaml```

--- a/README.md
+++ b/README.md
@@ -431,8 +431,3 @@ $ ./remove-storage-class.sh
 ```
 
 > Note: the NFS persistence data will not be deleted by default.
-
-
-```kubectl apply -f rocketmq-operator.yaml```
-
-```kubectl apply -f rocketmq-cluster.yaml```

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,8 +24,8 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/apis"
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/controller"
+	"github.com/apache/rocketmq-operator/pkg/apis"
+	"github.com/apache/rocketmq-operator/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"

--- a/deploy/crds/rocketmq_v1alpha1_topictransfer_crd.yaml
+++ b/deploy/crds/rocketmq_v1alpha1_topictransfer_crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: topictransfers.rocketmq.apache.org
+spec:
+  group: rocketmq.apache.org
+  names:
+    kind: TopicTransfer
+    listKind: TopicTransferList
+    plural: topictransfers
+    singular: topictransfer
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            consumerGroup:
+              description: Consumer group
+              type: string
+            sourceCluster:
+              description: The cluster where the transferred topic from
+              type: string
+            targetCluster:
+              description: The cluster where the topic will be transferred to
+              type: string
+            topic:
+              description: Topic name
+              type: string
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/crds/rocketmq_v1alpha1_topictransfer_crd.yaml
+++ b/deploy/crds/rocketmq_v1alpha1_topictransfer_crd.yaml
@@ -29,9 +29,6 @@ spec:
           type: object
         spec:
           properties:
-            consumerGroup:
-              description: Consumer group
-              type: string
             sourceCluster:
               description: The cluster where the transferred topic from
               type: string

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -53,5 +53,6 @@ rules:
   - '*'
   - brokers
   - pods/exec
+  - topictransfers
   verbs:
   - '*'

--- a/example/rocketmq_v1alpha1_topictransfer_cr.yaml
+++ b/example/rocketmq_v1alpha1_topictransfer_cr.yaml
@@ -23,6 +23,6 @@ spec:
   # consumerGroup defines the consumer group
   consumerGroup: please_rename_unique_group_name_4
   # sourceCluster define the source cluster
-  sourceCluster: broker
+  sourceCluster: broker-0
   # targetCluster defines the target cluster
-  targetCluster: targetbroker
+  targetCluster: broker-1

--- a/example/rocketmq_v1alpha1_topictransfer_cr.yaml
+++ b/example/rocketmq_v1alpha1_topictransfer_cr.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rocketmq.apache.org/v1alpha1
+kind: TopicTransfer
+metadata:
+  name: topictransfer
+spec:
+  # topic defines which topic to be transferred
+  topic: TopicTest
+  # consumerGroup defines the consumer group
+  consumerGroup: please_rename_unique_group_name_4
+  # sourceCluster define the source cluster
+  sourceCluster: broker
+  # targetCluster defines the target cluster
+  targetCluster: targetbroker

--- a/example/rocketmq_v1alpha1_topictransfer_cr.yaml
+++ b/example/rocketmq_v1alpha1_topictransfer_cr.yaml
@@ -20,8 +20,6 @@ metadata:
 spec:
   # topic defines which topic to be transferred
   topic: TopicTest
-  # consumerGroup defines the consumer group
-  consumerGroup: please_rename_unique_group_name_4
   # sourceCluster define the source cluster
   sourceCluster: broker-0
   # targetCluster defines the target cluster

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/operator-sdk-samples/rocketmq-operator
+module github.com/apache/rocketmq-operator
 
 go 1.12
 

--- a/install-operator.sh
+++ b/install-operator.sh
@@ -17,6 +17,7 @@
 
 kubectl create -f deploy/crds/rocketmq_v1alpha1_broker_crd.yaml
 kubectl create -f deploy/crds/rocketmq_v1alpha1_nameservice_crd.yaml
+kubectl create -f deploy/crds/rocketmq_v1alpha1_topictransfer_cr.yaml
 kubectl create -f deploy/service_account.yaml
 kubectl create -f deploy/role.yaml
 kubectl create -f deploy/role_binding.yaml

--- a/pkg/apis/addtoscheme_rocketmq_v1alpha1.go
+++ b/pkg/apis/addtoscheme_rocketmq_v1alpha1.go
@@ -18,7 +18,7 @@
 package apis
 
 import (
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
+	"github.com/apache/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
 )
 
 func init() {

--- a/pkg/apis/rocketmq/v1alpha1/topictransfer_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/topictransfer_types.go
@@ -33,8 +33,6 @@ type TopicTransferSpec struct {
 
 	// Topic name
 	Topic string `json:"topic,omitempty"`
-	// Consumer group
-	ConsumerGroup string `json:"consumerGroup,omitempty"`
 	// The cluster where the transferred topic from
 	SourceCluster string `json:"sourceCluster,omitempty"`
 	// The cluster where the topic will be transferred to

--- a/pkg/apis/rocketmq/v1alpha1/topictransfer_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/topictransfer_types.go
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
+// TopicTransferSpec defines the desired state of TopicTransfer
+// +k8s:openapi-gen=true
+type TopicTransferSpec struct {
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
+	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+
+	// Topic name
+	Topic string `json:"topic,omitempty"`
+	// Consumer group
+	ConsumerGroup string `json:"consumerGroup,omitempty"`
+	// The cluster where the transferred topic from
+	SourceCluster string `json:"sourceCluster,omitempty"`
+	// The cluster where the topic will be transferred to
+	TargetCluster string `json:"targetCluster,omitempty"`
+}
+
+// TopicTransferStatus defines the observed state of TopicTransfer
+// +k8s:openapi-gen=true
+type TopicTransferStatus struct {
+	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
+	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TopicTransfer is the Schema for the topictransfers API
+// +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
+type TopicTransfer struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   TopicTransferSpec   `json:"spec,omitempty"`
+	Status TopicTransferStatus `json:"status,omitempty"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// TopicTransferList contains a list of TopicTransfer
+type TopicTransferList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []TopicTransfer `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&TopicTransfer{}, &TopicTransferList{})
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -19,6 +19,7 @@ package constants
 
 const BrokerClusterPrefix = "broker-cluster-"
 const BrokerContainerName = "broker"
+const BasicCommand = "sh"
 const AdminToolDir = "/home/rocketmq/rocketmq-4.5.0/bin/mqadmin"
 const StoreConfigDir = "/home/rocketmq/store/config"
 const TopicJsonDir = "/home/rocketmq/store/config/topics.json"
@@ -42,12 +43,19 @@ const BrokerMainContainerPort  = 10911
 const BrokerMainContainerPortName = "main"
 const BrokerHighAvailabilityContainerPort  = 10912
 const BrokerHighAvailabilityContainerPortName = "ha"
-
+// storage modes
 const StorageModeNFS  = "NFS"
 const StorageModeEmptyDir  = "EmptyDir"
 const StorageModeHostPath  = "HostPath"
-
+// threshold values
 const RestartBrokerPodIntervalInSecond  = 30
 const MinMetadataJsonFileSize  = 5
 const MinIpListLength  = 8
-
+const CheckConsumeFinishIntervalInSecond = 5
+const RequeueIntervalInSecond = 6
+// fields
+const TopicIndex = 0
+const BrokerNameIndex = 1
+const DiffIndex = 6
+const TopicListTopic = 1
+const TopicListConsumerGroup = 2

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -49,4 +49,5 @@ const StorageModeHostPath  = "HostPath"
 
 const RestartBrokerPodIntervalInSecond  = 30
 const MinMetadataJsonFileSize  = 5
+const MinIpListLength  = 8
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,6 +20,7 @@ package constants
 const BrokerClusterPrefix = "broker-cluster-"
 const BrokerContainerName = "broker"
 const AdminToolDir = "/home/rocketmq/rocketmq-4.5.0/bin/mqadmin"
+const StoreConfigDir = "/home/rocketmq/store/config"
 const TopicJsonDir = "/home/rocketmq/store/config/topics.json"
 const SubscriptionGroupJsonDir = "/home/rocketmq/store/config/subscriptionGroup.json"
 const UpdateBrokerConfig  = "updateBrokerConfig"

--- a/pkg/controller/add_broker.go
+++ b/pkg/controller/add_broker.go
@@ -18,7 +18,7 @@
 package controller
 
 import (
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/controller/broker"
+	"github.com/apache/rocketmq-operator/pkg/controller/broker"
 )
 
 func init() {

--- a/pkg/controller/add_nameservice.go
+++ b/pkg/controller/add_nameservice.go
@@ -18,7 +18,7 @@
 package controller
 
 import (
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/controller/nameservice"
+	"github.com/apache/rocketmq-operator/pkg/controller/nameservice"
 )
 
 func init() {

--- a/pkg/controller/add_topictransfer.go
+++ b/pkg/controller/add_topictransfer.go
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"github.com/apache/rocketmq-operator/pkg/controller/topictransfer"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, topictransfer.Add)
+}

--- a/pkg/controller/broker/broker_controller.go
+++ b/pkg/controller/broker/broker_controller.go
@@ -308,7 +308,7 @@ func (r *ReconcileBroker) Reconcile(request reconcile.Request) (reconcile.Result
 	//	}
 	//}
 
-	return reconcile.Result{true, time.Duration(3) * time.Second}, nil
+	return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(cons.RequeueIntervalInSecond) * time.Second}, nil
 }
 
 func getCopyMetadataJsonCommand(dir string, sourcePodName string, namespace string, k8s *tool.K8sClient) string {
@@ -414,7 +414,7 @@ func (r *ReconcileBroker) getBrokerStatefulSet(broker *rocketmqv1alpha1.Broker, 
 							Value: strconv.Itoa(replicaIndex),
 						}, {
 							Name:  cons.EnvBrokerClusterName,
-							Value: broker.Name,
+							Value: broker.Name + "-" + strconv.Itoa(brokerGroupIndex),
 						}, {
 							Name:  cons.EnvBrokerName,
 							Value: broker.Name + "-" + strconv.Itoa(brokerGroupIndex),

--- a/pkg/controller/broker/broker_controller.go
+++ b/pkg/controller/broker/broker_controller.go
@@ -260,7 +260,6 @@ func (r *ReconcileBroker) Reconcile(request reconcile.Request) (reconcile.Result
 			log.Info("subscriptionGroupCommand: " + subscriptionGroupCommand)
 			MakeConfigDirCommand := "mkdir -p " + cons.StoreConfigDir
 			ChmodDirCommand := "chmod a+rw " + cons.StoreConfigDir
-			log.Info("ChmodDirCommand: " + ChmodDirCommand)
 			cmd = []string{"/bin/bash", "-c", MakeConfigDirCommand + " && " + ChmodDirCommand + " && " + topicsCommand + " && " + subscriptionGroupCommand}
 		}
 	}

--- a/pkg/controller/broker/broker_controller.go
+++ b/pkg/controller/broker/broker_controller.go
@@ -24,10 +24,10 @@ import (
 	"strings"
 	"time"
 
-	rocketmqv1alpha1 "github.com/operator-sdk-samples/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
-	cons "github.com/operator-sdk-samples/rocketmq-operator/pkg/constants"
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/share"
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/tool"
+	rocketmqv1alpha1 "github.com/apache/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
+	cons "github.com/apache/rocketmq-operator/pkg/constants"
+	"github.com/apache/rocketmq-operator/pkg/share"
+	"github.com/apache/rocketmq-operator/pkg/tool"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -258,7 +258,9 @@ func (r *ReconcileBroker) Reconcile(request reconcile.Request) (reconcile.Result
 			log.Info("topicsCommand: " + topicsCommand)
 			subscriptionGroupCommand := getCopyMetadataJsonCommand(cons.SubscriptionGroupJsonDir, sourcePodName, broker.Namespace, k8s)
 			log.Info("subscriptionGroupCommand: " + subscriptionGroupCommand)
-			cmd = []string{"/bin/bash", "-c", topicsCommand + " && " + subscriptionGroupCommand}
+			MakeConfigDirCommand := "mkdir -p " + cons.StoreConfigDir
+			ChmodDirCommand := "chmod a+rw -R " + cons.StoreConfigDir
+			cmd = []string{"/bin/bash", "-c", MakeConfigDirCommand + " && " + ChmodDirCommand + " && " + topicsCommand + " && " + subscriptionGroupCommand}
 		}
 	}
 

--- a/pkg/controller/broker/broker_controller.go
+++ b/pkg/controller/broker/broker_controller.go
@@ -259,7 +259,8 @@ func (r *ReconcileBroker) Reconcile(request reconcile.Request) (reconcile.Result
 			subscriptionGroupCommand := getCopyMetadataJsonCommand(cons.SubscriptionGroupJsonDir, sourcePodName, broker.Namespace, k8s)
 			log.Info("subscriptionGroupCommand: " + subscriptionGroupCommand)
 			MakeConfigDirCommand := "mkdir -p " + cons.StoreConfigDir
-			ChmodDirCommand := "chmod a+rw -R " + cons.StoreConfigDir
+			ChmodDirCommand := "chmod a+rw " + cons.StoreConfigDir
+			log.Info("ChmodDirCommand: " + ChmodDirCommand)
 			cmd = []string{"/bin/bash", "-c", MakeConfigDirCommand + " && " + ChmodDirCommand + " && " + topicsCommand + " && " + subscriptionGroupCommand}
 		}
 	}
@@ -327,10 +328,11 @@ func buildInputCommand(source string) []string {
 }
 
 func buildOutputCommand(content string, dest string) []string {
+	replaced := strings.Replace(content,"\"","\\\"", -1)
 	cmdOpts := []string{
 		"echo",
 		"-e",
-		"\"" + content + "\"",
+		"\"" + replaced + "\"",
 		">",
 		dest,
 	}

--- a/pkg/controller/broker/broker_controller_test.go
+++ b/pkg/controller/broker/broker_controller_test.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"testing"
 
-	rocketmqv1alpha1 "github.com/operator-sdk-samples/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
+	rocketmqv1alpha1 "github.com/apache/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/nameservice/nameservice_controller.go
+++ b/pkg/controller/nameservice/nameservice_controller.go
@@ -24,9 +24,9 @@ import (
 	"strconv"
 	"time"
 
-	rocketmqv1alpha1 "github.com/operator-sdk-samples/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
-	cons "github.com/operator-sdk-samples/rocketmq-operator/pkg/constants"
-	"github.com/operator-sdk-samples/rocketmq-operator/pkg/share"
+	rocketmqv1alpha1 "github.com/apache/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
+	cons "github.com/apache/rocketmq-operator/pkg/constants"
+	"github.com/apache/rocketmq-operator/pkg/share"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/nameservice/nameservice_controller.go
+++ b/pkg/controller/nameservice/nameservice_controller.go
@@ -188,9 +188,9 @@ func (r *ReconcileNameService) updateNameServiceStatus(instance *rocketmqv1alpha
 		share.NameServersStr = nameServerListStr[:len(nameServerListStr)-1]
 		reqLogger.Info("share.NameServersStr:" + share.NameServersStr)
 
-		if len(oldNameServerListStr) < 8 {
+		if len(oldNameServerListStr) <= cons.MinIpListLength {
 			oldNameServerListStr = share.NameServersStr
-		} else if len(share.NameServersStr) > 8 {
+		} else if len(share.NameServersStr) > cons.MinIpListLength {
 			oldNameServerListStr = oldNameServerListStr[:len(oldNameServerListStr)-1]
 			share.IsNameServersStrUpdated = true
 		}
@@ -206,7 +206,7 @@ func (r *ReconcileNameService) updateNameServiceStatus(instance *rocketmqv1alpha
 		}
 
 		// use admin tool to update broker config
-		if share.IsNameServersStrUpdated && (len(oldNameServerListStr) > 8) && (len(share.NameServersStr) > 8) {
+		if share.IsNameServersStrUpdated && (len(oldNameServerListStr) > cons.MinIpListLength) && (len(share.NameServersStr) > cons.MinIpListLength) {
 			mqAdmin := cons.AdminToolDir
 			subCmd := cons.UpdateBrokerConfig
 			key := cons.ParamNameServiceAddress

--- a/pkg/controller/nameservice/nameservice_controller.go
+++ b/pkg/controller/nameservice/nameservice_controller.go
@@ -232,7 +232,7 @@ func (r *ReconcileNameService) updateNameServiceStatus(instance *rocketmqv1alpha
 	}
 
 	if requeue {
-		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3)*time.Second}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(cons.RequeueIntervalInSecond)*time.Second}, nil
 	} else {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/topictransfer/topictransfer_controller.go
+++ b/pkg/controller/topictransfer/topictransfer_controller.go
@@ -1,0 +1,348 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package topictransfer
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	rocketmqv1alpha1 "github.com/apache/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
+	cons "github.com/apache/rocketmq-operator/pkg/constants"
+	"github.com/apache/rocketmq-operator/pkg/share"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_topictransfer")
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new TopicTransfer Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileTopicTransfer{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("topictransfer-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource TopicTransfer
+	err = c.Watch(&source.Kind{Type: &rocketmqv1alpha1.TopicTransfer{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner TopicTransfer
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &rocketmqv1alpha1.TopicTransfer{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileTopicTransfer implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileTopicTransfer{}
+
+// ReconcileTopicTransfer reconciles a TopicTransfer object
+type ReconcileTopicTransfer struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a TopicTransfer object and makes changes based on the state read
+// and what is in the TopicTransfer.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileTopicTransfer) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling TopicTransfer")
+
+	// Fetch the TopicTransfer topicTransfer
+	topicTransfer := &rocketmqv1alpha1.TopicTransfer{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, topicTransfer)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// TODO: if ConsumerGroup could be decided by listing the topics
+
+	// TODO: what if current name server is compromised
+	// step1: add consumer group to target cluster
+	nameServer := strings.Split(share.NameServersStr, ";")[0]
+	consumerGroup := topicTransfer.Spec.ConsumerGroup
+	targetCluster := topicTransfer.Spec.TargetCluster
+	sourceCluster := topicTransfer.Spec.SourceCluster
+	topic := topicTransfer.Spec.Topic
+
+	addConsumerGroupToTargetCluster := buildAddConsumerGroupToClusterCommand(consumerGroup, targetCluster, nameServer)
+	addConsumerGroupToTargetClusterCommand := strings.Join(addConsumerGroupToTargetCluster, " ")
+	reqLogger.Info("AddConsumerGroupToTargetClusterCommand: " + addConsumerGroupToTargetClusterCommand)
+	cmd := exec.Command("sh", addConsumerGroupToTargetClusterCommand)
+	output, err := cmd.Output()
+	if err != nil {
+		reqLogger.Error(err, "Failed to add ConsumerGroup " + consumerGroup + " to TargetCluster " + targetCluster)
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3) * time.Second}, err
+	}
+	// isAddConsumerGroupToTargetClusterOutputValid(string(output))
+	reqLogger.Info("Successfully add ConsumerGroup " + consumerGroup + " to TargetCluster " + targetCluster + " with output: " + string(output))
+
+	// step2: add consumer group to target cluster
+	addTopicToTargetCluster := buildAddTopicToClusterCommand(topic, targetCluster, nameServer)
+	addTopicToTargetClusterCommand := strings.Join(addTopicToTargetCluster, " ")
+	reqLogger.Info("addTopicToTargetClusterCommand: " + addTopicToTargetClusterCommand)
+	cmd = exec.Command("sh", addTopicToTargetClusterCommand)
+	output, err = cmd.Output()
+	if err != nil {
+		reqLogger.Error(err, "Failed to add Topic " + topic + " to TargetCluster " + targetCluster)
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3) * time.Second}, err
+	}
+	// TODO: verify output of addTopicToTargetClusterCommand
+	reqLogger.Info("Successfully add Topic " + topic + " to TargetCluster " + targetCluster + " with output: " + string(output))
+
+	// step3: stop write in source cluster topic
+	stopSourceClusterTopicWrite := buildStopClusterTopicWriteCommand(topic, sourceCluster, nameServer)
+	stopSourceClusterTopicWriteCommand := strings.Join(stopSourceClusterTopicWrite, " ")
+	reqLogger.Info("stopSourceClusterTopicWriteCommand: " + stopSourceClusterTopicWriteCommand)
+	cmd = exec.Command("sh", stopSourceClusterTopicWriteCommand)
+	output, err = cmd.Output()
+	if err != nil {
+		reqLogger.Error(err, "Failed to stop Topic " + topic + " write in SourceCluster " + sourceCluster)
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3) * time.Second}, err
+	}
+	// TODO: verify output of stopSourceClusterTopicWriteCommand
+	reqLogger.Info("Successfully stop Topic " + topic + " write in SourceCluster " + sourceCluster + " with output: " + string(output))
+
+	// step4: check source cluster unconsumed message
+	for {
+		checkConsumeProgress := buildCheckConsumeProgressCommand(consumerGroup, nameServer)
+		checkConsumeProgressCommand := strings.Join(checkConsumeProgress, " ")
+		reqLogger.Info("checkConsumeProgressCommand: " + checkConsumeProgressCommand)
+		cmd = exec.Command("sh", checkConsumeProgressCommand)
+		output, err = cmd.Output()
+		if err != nil {
+			reqLogger.Error(err, "Failed to check consumerGroup " + consumerGroup)
+			return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3) * time.Second}, err
+		}
+		var finished bool = isConsumeFinished(string(output))
+		reqLogger.Info(" output: " + string(output))
+		if finished {
+			break
+		}
+		time.Sleep(time.Duration(5) * time.Second)
+	}
+
+	// step5: delete topic in source cluster
+	deleteSourceClusterTopic := buildDeleteSourceClusterTopicCommand(topic, sourceCluster, nameServer)
+	deleteSourceClusterTopicCommand := strings.Join(deleteSourceClusterTopic, " ")
+	reqLogger.Info("deleteSourceClusterTopicCommand: " + deleteSourceClusterTopicCommand)
+	cmd = exec.Command("sh", deleteSourceClusterTopicCommand)
+	output, err = cmd.Output()
+	if err != nil {
+		reqLogger.Error(err, "Failed to delete Topic " + topic + " in SourceCluster " + sourceCluster)
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3) * time.Second}, err
+	}
+	// TODO: verify output
+	reqLogger.Info("Successfully delete Topic " + topic + " in SourceCluster " + sourceCluster + " with output: " + string(output))
+
+	// step6: delete consumer group in source cluster
+	deleteConsumerGroup := buildDeleteConsumeGroupCommand(consumerGroup, sourceCluster, nameServer)
+	deleteConsumerGroupCommand := strings.Join(deleteConsumerGroup, " ")
+	reqLogger.Info("deleteConsumerGroupCommand: " + deleteConsumerGroupCommand)
+	cmd = exec.Command("sh", deleteConsumerGroupCommand)
+	output, err = cmd.Output()
+	if err != nil {
+		reqLogger.Error(err, "Failed to delete consumer group " + consumerGroup + " in SourceCluster " + sourceCluster)
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3) * time.Second}, err
+	}
+	// TODO: verify output
+	reqLogger.Info("Successfully delete consumer group " + consumerGroup + " in SourceCluster " + sourceCluster + " with output: " + string(output))
+
+	// step7: create retry topic
+	createRetryTopic := buildAddRetryTopicToClusterCommand(consumerGroup, targetCluster, nameServer)
+	createRetryTopicCommand := strings.Join(createRetryTopic, " ")
+	reqLogger.Info("createRetryTopicCommand: " + createRetryTopicCommand)
+	cmd = exec.Command("sh", createRetryTopicCommand)
+	output, err = cmd.Output()
+	if err != nil {
+		reqLogger.Error(err, "Failed to create retry topic of consumer group " + consumerGroup + " in TargetCluster " + targetCluster)
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(3) * time.Second}, err
+	}
+	// TODO: verify output
+	reqLogger.Info("Successfully create retry topic of consumer group " + consumerGroup + " in TargetCluster " + targetCluster + " with output: " + string(output))
+
+	reqLogger.Info("Topic " + topic + " has been transferred from " + sourceCluster + " to " + targetCluster)
+	return reconcile.Result{}, nil
+}
+
+func buildAddRetryTopicToClusterCommand(consumerGroup string, cluster string, nameServer string) []string {
+	cmdOpts := []string{
+		cons.AdminToolDir,
+		"updatetopic",
+		"-t",
+		"%RETRY%" + consumerGroup,
+		"-c",
+		cluster,
+		"-r",
+		"1",
+		"-w",
+		"1",
+		"-p",
+		"6",
+		"-n",
+		nameServer,
+	}
+	return cmdOpts
+}
+
+func isConsumeFinished(output string) bool {
+	return true
+}
+
+func buildDeleteConsumeGroupCommand(consumerGroup string, cluster string, nameServer string) []string {
+	cmdOpts := []string{
+		cons.AdminToolDir,
+		"deleteSubGroup",
+		"-g",
+		consumerGroup,
+		"-c",
+		cluster,
+		"-n",
+		nameServer,
+	}
+	return cmdOpts
+}
+
+func buildDeleteSourceClusterTopicCommand(topic string, sourceCluster string, nameServer string) []string {
+	cmdOpts := []string{
+		cons.AdminToolDir,
+		"deletetopic",
+		"-t",
+		topic,
+		"-c",
+		sourceCluster,
+		"-n",
+		nameServer,
+	}
+	return cmdOpts
+}
+
+func isAddConsumerGroupToTargetClusterOutputValid(s string)  {
+
+}
+
+func buildCheckConsumeProgressCommand(consumerGroup string, nameServer string) []string {
+	cmdOpts := []string{
+		cons.AdminToolDir,
+		"consumerprogress",
+		"-g",
+		consumerGroup,
+		"-n",
+		nameServer,
+	}
+	return cmdOpts
+}
+
+func buildStopClusterTopicWriteCommand(topic string, cluster string, nameServer string) []string {
+	cmdOpts := []string{
+		cons.AdminToolDir,
+		"updatetopic",
+		"-t",
+		topic,
+		"-c",
+		cluster,
+		"-p",
+		"4",
+		"-w",
+		"0",
+		"-n",
+		nameServer,
+	}
+	return cmdOpts
+}
+
+func buildAddConsumerGroupToClusterCommand(consumerGroup string, cluster string, nameServer string) []string {
+	cmdOpts := []string{
+		cons.AdminToolDir,
+		"updatesubgroup",
+		"-g",
+		consumerGroup,
+		"-c",
+		cluster,
+		"-m",
+		"true",
+		"-d",
+		"true",
+		"-n",
+		nameServer,
+	}
+	return cmdOpts
+}
+
+func buildAddTopicToClusterCommand(topic string, cluster string, nameServer string) []string {
+	cmdOpts := []string{
+		cons.AdminToolDir,
+		"updatetopic",
+		"-t",
+		topic,
+		"-c",
+		cluster,
+		"-n",
+		nameServer,
+	}
+	return cmdOpts
+}

--- a/purge-operator.sh
+++ b/purge-operator.sh
@@ -25,4 +25,4 @@ kubectl delete -f deploy/role.yaml
 kubectl delete -f deploy/service_account.yaml
 kubectl delete -f deploy/crds/rocketmq_v1alpha1_broker_crd.yaml
 kubectl delete -f deploy/crds/rocketmq_v1alpha1_nameservice_crd.yaml
-
+kubectl delete -f deploy/crds/rocketmq_v1alpha1_topictransfer_crd.yaml

--- a/test/e2e/memcached_test.go
+++ b/test/e2e/memcached_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
-	apis "github.com/operator-sdk-samples/rocketmq-operator/pkg/apis"
-	operator "github.com/operator-sdk-samples/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
+	apis "github.com/apache/rocketmq-operator/pkg/apis"
+	operator "github.com/apache/rocketmq-operator/pkg/apis/rocketmq/v1alpha1"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"


### PR DESCRIPTION
Change List:
1. Add a new feature of topic transfer operation with corresponding CRD and controller.
2. Add some implementations of operation undo-process for topic transfer operation atomicity.
3. Add some docs about the new feature ```Topic Transfer```
4. Fix a bug that happens when scaling up broker cluster if config path does not exist.
5. Replace some magic numbers with constants.