### PR TITLE
[ISSUE #30] Auto-configure NameServer IP List

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ spec:
   # size is the number of the broker cluster, each broker cluster contains a master broker and [replicaPerGroup] replica brokers.
   size: 2
   # nameServers is the [ip:port] list of name service
-  nameServers: 192.168.130.33:9876
+  nameServers: ""
   # replicationMode is the broker replica sync mode, can be ASYNC or SYNC
   replicationMode: ASYNC
   # replicaPerGroup is the number of replica broker in each group
@@ -235,7 +235,7 @@ spec:
           requests:
             storage: 8Gi
 ``` 
-which defines the RocketMQ broker cluster scale, the [ip:port] list of name service and so on.
+which defines the RocketMQ broker cluster scale, the [ip:port] list of name service and so on. By default, the nameServers is an empty string which means it is automatically obtained by the operator.
 
 ### Create RocketMQ Cluster
 
@@ -256,7 +256,7 @@ nfs-client-provisioner-7cf858f754-7vxmm   1/1     Running   0          150m    1
 rocketmq-operator-564b5d75d-jllzk         1/1     Running   0          5m53s   10.244.2.116     k2data-14   <none>           <none>
 ```
 
-We can see that there are 1 name service Pods running on 1 nodes and their IP addresses. Modify the ```nameServers``` field in the ```rocketmq_v1alpha1_broker_cr.yaml``` file using the IP addresses.
+We can see We can see that there are 1 name service Pod running on 1 node.
 
 2. Deploy the RocketMQ broker clusters by running:
 ```

--- a/create-operator.sh
+++ b/create-operator.sh
@@ -18,7 +18,7 @@
 set -eux;
 
 # You can change the DOCKERHUB_REPO to your docker repo for development purpose
-DOCKERHUB_REPO="apacherocketmq/rocketmq-operator:0.2.0"
+DOCKERHUB_REPO="2019liurui/rocketmq-operator:0.2.1"
 # The version of RocketMQ including the Admin Tool
 ROCKETMQ_VERSION="4.5.0"
 
@@ -26,7 +26,7 @@ export GO111MODULE=on
 
 # Download rocketmq.zip for the Admin Tool if it does not exist
 if [ ! -e build/rocketmq.zip ]; then
-  curl https://dist.apache.org/repos/dist/release/rocketmq/${ROCKETMQ_VERSION}/rocketmq-all-${ROCKETMQ_VERSION}-bin-release.zip -o rocketmq.zip
+  curl https://archive.apache.org/dist/rocketmq/${ROCKETMQ_VERSION}/rocketmq-all-${ROCKETMQ_VERSION}-bin-release.zip -o rocketmq.zip
   mv rocketmq.zip build
 fi
 

--- a/create-operator.sh
+++ b/create-operator.sh
@@ -18,7 +18,7 @@
 set -eux;
 
 # You can change the DOCKERHUB_REPO to your docker repo for development purpose
-DOCKERHUB_REPO="2019liurui/rocketmq-operator:0.2.1"
+DOCKERHUB_REPO="apacherocketmq/rocketmq-operator:0.2.1"
 # The version of RocketMQ including the Admin Tool
 ROCKETMQ_VERSION="4.5.0"
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: rocketmq-operator
           # Replace this with the built image name
-          image: apacherocketmq/rocketmq-operator:0.2.0
+          image: 2019liurui/rocketmq-operator:0.2.1
           command:
           - rocketmq-operator
           imagePullPolicy: Always

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,7 +31,7 @@ spec:
       containers:
         - name: rocketmq-operator
           # Replace this with the built image name
-          image: 2019liurui/rocketmq-operator:0.2.1
+          image: apacherocketmq/rocketmq-operator:0.2.1
           command:
           - rocketmq-operator
           imagePullPolicy: Always

--- a/example/rocketmq_v1alpha1_broker_cr.yaml
+++ b/example/rocketmq_v1alpha1_broker_cr.yaml
@@ -20,9 +20,9 @@ metadata:
   name: broker
 spec:
   # size is the number of the broker cluster, each broker cluster contains a master broker and [replicaPerGroup] replica brokers.
-  size: 2
+  size: 1
   # nameServers is the [ip:port] list of name service
-  nameServers: 192.168.130.33:9876
+  nameServers: ""
   # replicationMode is the broker replica sync mode, can be ASYNC or SYNC
   replicationMode: ASYNC
   # replicaPerGroup is the number of each broker cluster
@@ -34,7 +34,7 @@ spec:
   # allowRestart defines whether allow pod restart
   allowRestart: true
   # storageMode can be EmptyDir, HostPath, NFS
-  storageMode: HostPath
+  storageMode: EmptyDir
   # hostPath is the local path to store data
   hostPath: /data/rocketmq/broker
   # scalePodName is broker-[broker group number]-master-0

--- a/example/rocketmq_v1alpha1_nameservice_cr.yaml
+++ b/example/rocketmq_v1alpha1_nameservice_cr.yaml
@@ -25,7 +25,7 @@ spec:
   # imagePullPolicy is the image pull policy
   imagePullPolicy: Always
   # storageMode can be EmptyDir, HostPath, NFS
-  storageMode: HostPath
+  storageMode: EmptyDir
   # hostPath is the local path to store data
   hostPath: /data/rocketmq/nameserver
   # volumeClaimTemplates defines the storageClass

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-logr/zapr v0.1.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.0 // indirect
 	github.com/go-openapi/jsonreference v0.19.0 // indirect
-	github.com/go-openapi/spec v0.19.0
+	github.com/go-openapi/spec v0.19.0 // indirect
 	github.com/go-openapi/swag v0.19.0 // indirect
 	github.com/gobuffalo/envy v1.6.15 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
@@ -69,7 +69,7 @@ require (
 	k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a // indirect
 	k8s.io/helm v2.13.0+incompatible // indirect
 	k8s.io/klog v0.2.0 // indirect
-	k8s.io/kube-openapi v0.0.0-20180711000925-0cf8f7e6ed1d
+	k8s.io/kube-openapi v0.0.0-20180711000925-0cf8f7e6ed1d // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
 	sigs.k8s.io/controller-tools v0.1.8 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -106,6 +106,9 @@ const (
 	// RestartBrokerPodIntervalInSecond is restart broker pod interval in second
 	RestartBrokerPodIntervalInSecond = 30
 
+	// WaitForNameServerReadyInSecond is the time broker sleep for waiting nameserver ready in second
+	WaitForNameServerReadyInSecond = 1
+
 	// MinMetadataJsonFileSize is the threshold value if file length is lower than this will be considered as invalid
 	MinMetadataJsonFileSize = 5
 

--- a/pkg/controller/nameservice/nameservice_controller.go
+++ b/pkg/controller/nameservice/nameservice_controller.go
@@ -190,6 +190,7 @@ func (r *ReconcileNameService) updateNameServiceStatus(instance *rocketmqv1alpha
 
 		if len(oldNameServerListStr) <= cons.MinIpListLength {
 			oldNameServerListStr = share.NameServersStr
+			share.IsNameServersStrInitialized = true
 		} else if len(share.NameServersStr) > cons.MinIpListLength {
 			oldNameServerListStr = oldNameServerListStr[:len(oldNameServerListStr)-1]
 			share.IsNameServersStrUpdated = true

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -28,6 +28,9 @@ var (
 	// IsNameServersStrUpdated is whether the name server list is updated
 	IsNameServersStrUpdated = false
 
+	// IsNameServersStrInitialized is whether the name server list is initialized
+	IsNameServersStrInitialized = false
+
 	// BrokerClusterName is the broker cluster name
 	BrokerClusterName = ""
 )


### PR DESCRIPTION
Change list:
1. Add support for automatically obtaining name server IP list when create broker cluster.
2.Update the RocketMQ download link in create-operator.sh.