### PR TITLE
Security Contexts for Broker and Nameserver

### DIFF
--- a/pkg/apis/rocketmq/v1alpha1/broker_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/broker_types.go
@@ -56,6 +56,10 @@ type BrokerSpec struct {
 	VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates"`
 	// The name of pod where the metadata from
 	ScalePodName string `json:"scalePodName"`
+	// Pod Security Context
+	PodSecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	// Container Security Context
+	ContainerSecurityContext *corev1.SecurityContext `json:"containerSecurityContext,omitempty"`
 }
 
 // BrokerStatus defines the observed state of Broker

--- a/pkg/apis/rocketmq/v1alpha1/nameservice_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/nameservice_types.go
@@ -49,6 +49,10 @@ type NameServiceSpec struct {
 	HostPath string `json:"hostPath"`
 	// VolumeClaimTemplates defines the StorageClass
 	VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates"`
+	// Pod Security Context
+	PodSecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	// Container Security Context
+	ContainerSecurityContext *corev1.SecurityContext `json:"containerSecurityContext,omitempty"`
 }
 
 // NameServiceStatus defines the observed state of NameService


### PR DESCRIPTION
 - Added SC for Broker and Nameserver
 - Security Context added at  both pod and container level
 - Since rocketmq docker image runs with UID 3000 its good to run pods with sc bound policy.