### PR TITLE
[ISSUE #100]Add printcolomns to operator resources

### DIFF
--- a/deploy/crds/rocketmq.apache.org_brokers.yaml
+++ b/deploy/crds/rocketmq.apache.org_brokers.yaml
@@ -16,7 +16,20 @@ spec:
     singular: broker
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.size
+      name: Size
+      type: integer
+    - jsonPath: .spec.replicaPerGroup
+      name: Replica-Per-Group
+      type: integer
+    - jsonPath: .spec.allowRestart
+      name: Allow-Restart
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Broker is the Schema for the brokers API

--- a/deploy/crds/rocketmq.apache.org_consoles.yaml
+++ b/deploy/crds/rocketmq.apache.org_consoles.yaml
@@ -16,7 +16,14 @@ spec:
     singular: console
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.consoleDeployment.spec.replicas
+      name: Size
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Console is the Schema for the consoles API

--- a/deploy/crds/rocketmq.apache.org_nameservices.yaml
+++ b/deploy/crds/rocketmq.apache.org_nameservices.yaml
@@ -16,7 +16,17 @@ spec:
     singular: nameservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.size
+      name: Size
+      type: integer
+    - jsonPath: .spec.hostNetwork
+      name: Host-Network
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NameService is the Schema for the nameservices API

--- a/pkg/apis/rocketmq/v1alpha1/broker_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/broker_types.go
@@ -86,6 +86,10 @@ type BrokerStatus struct {
 
 // Broker is the Schema for the brokers API
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="Size",type="integer",JSONPath=".spec.size"
+// +kubebuilder:printcolumn:name="Replica-Per-Group",type="integer",JSONPath=".spec.replicaPerGroup"
+// +kubebuilder:printcolumn:name="Allow-Restart",type="boolean",JSONPath=".spec.allowRestart"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 type Broker struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/rocketmq/v1alpha1/console_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/console_types.go
@@ -49,6 +49,8 @@ type ConsoleStatus struct {
 // Console is the Schema for the consoles API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Size",type="integer",JSONPath=".spec.consoleDeployment.spec.replicas"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=consoles,scope=Namespaced
 type Console struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/rocketmq/v1alpha1/nameservice_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/nameservice_types.go
@@ -79,6 +79,9 @@ type NameServiceStatus struct {
 
 // NameService is the Schema for the nameservices API
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="Size",type="integer",JSONPath=".spec.size"
+// +kubebuilder:printcolumn:name="Host-Network",type="boolean",JSONPath=".spec.hostNetwork"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status
 type NameService struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Ref. #100 

The effect is shown below

```
$ kubectl get nameservice
NAME           SIZE   HOST-NETWORK   AGE
name-service   2      false          15m
```

```
$ kubectl get broker
NAME     SIZE   REPLICA-PER-GROUP   ALLOW-RESTART   AGE
broker   1      1                   true            15m
```

```
$ kubectl get console
NAME      SIZE   AGE
console   1      78m
```

