### PR TITLE
[ISSUE #120] fix(nameservice): add sorting for hostIps and instance.Status.NameServers before deepEqual

### DIFF
--- a/pkg/controller/nameservice/nameservice_controller.go
+++ b/pkg/controller/nameservice/nameservice_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/uuid"
 	"os/exec"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -178,6 +179,9 @@ func (r *ReconcileNameService) updateNameServiceStatus(instance *rocketmqv1alpha
 		return reconcile.Result{Requeue: true}, err
 	}
 	hostIps := getNameServers(podList.Items)
+
+	sort.Strings(hostIps)
+	sort.Strings(instance.Status.NameServers)
 
 	// Update status.NameServers if needed
 	if !reflect.DeepEqual(hostIps, instance.Status.NameServers) {


### PR DESCRIPTION
Sometimes, hostsIps are equal to instance.Status.NameServers, just the order of value is different. But reflect.DeepEqual will return false to this situation, and it will update nameservices always.

For example, hostIps = ['192.168.2.1', '192.168.2.11'], instance.Status.NameServers = ['192.168.2.11', '192.168.2.1']