### PR TITLE
feat(broker): Support HostNetwork for broker

### DIFF
--- a/deploy/crds/rocketmq.apache.org_brokers.yaml
+++ b/deploy/crds/rocketmq.apache.org_brokers.yaml
@@ -1121,6 +1121,9 @@ spec:
                   - name
                   type: object
                 type: array
+              hostNetwork:
+                description: HostNetwork can be true or false
+                type: boolean
               hostPath:
                 description: HostPath is the local path to store data
                 type: string

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,7 @@ module github.com/apache/rocketmq-operator
 go 1.16
 
 require (
-	github.com/google/uuid v1.1.2 // indirect
-	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.15.0
+	github.com/google/uuid v1.1.2
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.22.1
 	k8s.io/apimachinery v0.22.1

--- a/images/broker/alpine/brokerGenConfig.sh
+++ b/images/broker/alpine/brokerGenConfig.sh
@@ -27,6 +27,7 @@ function create_config() {
     echo "brokerClusterName=$BROKER_CLUSTER_NAME" >> $BROKER_CONFIG_FILE
     echo "brokerName=$BROKER_NAME" >> $BROKER_CONFIG_FILE
     echo "brokerId=$BROKER_ID" >> $BROKER_CONFIG_FILE
+    echo "brokerIP1=`hostname -i`" >> $BROKER_CONFIG_FILE
     if [ $BROKER_ID != 0 ]; then
         sed -i 's/brokerRole=.*/brokerRole=SLAVE/g' $BROKER_CONFIG_FILE
     fi

--- a/pkg/apis/rocketmq/v1alpha1/broker_types.go
+++ b/pkg/apis/rocketmq/v1alpha1/broker_types.go
@@ -40,6 +40,8 @@ type BrokerSpec struct {
 	BrokerImage string `json:"brokerImage"`
 	// ImagePullPolicy defines how the image is pulled
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy"`
+	// HostNetwork can be true or false
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 	// AllowRestart defines whether allow pod restart
 	AllowRestart bool `json:"allowRestart"`
 	// Resources describes the compute resource requirements

--- a/pkg/controller/broker/broker_controller.go
+++ b/pkg/controller/broker/broker_controller.go
@@ -426,6 +426,7 @@ func (r *ReconcileBroker) getBrokerStatefulSet(broker *rocketmqv1alpha1.Broker, 
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
+					HostNetwork:       broker.Spec.HostNetwork,
 					Affinity:          broker.Spec.Affinity,
 					Tolerations:       broker.Spec.Tolerations,
 					NodeSelector:      broker.Spec.NodeSelector,


### PR DESCRIPTION
Sometimes, it will access RocketMQ Cluster from outside the Kubernetes cluster. The client get broker ip and port from nameserver. If not use host network, the broker ip will be kubernetes pod ip, and the client cannot access this pod ip.