### PR TITLE
[ISSUE #123] Fix the nameServerListStr empty bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=rocketmq-operator crd:generateEmbeddedObjectMeta=true webhook paths="./..." output:dir=deploy output:crd:artifacts:config=deploy/crds
+	head -n 14 deploy/role_binding.yaml > deploy/role.yaml.bak
+	cat deploy/role.yaml >> deploy/role.yaml.bak
+	rm deploy/role.yaml && mv deploy/role.yaml.bak deploy/role.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/deploy/crds/rocketmq.apache.org_brokers.yaml
+++ b/deploy/crds/rocketmq.apache.org_brokers.yaml
@@ -49,9 +49,6 @@ spec:
           spec:
             description: BrokerSpec defines the desired state of Broker
             properties:
-              ServiceAccountName:
-                description: ServiceAccountName
-                type: string
               affinity:
                 description: Affinity the pod's scheduling constraints
                 properties:
@@ -1356,6 +1353,9 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountName:
+                description: ServiceAccountName
+                type: string
               size:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "operator-sdk generate k8s" to regenerate code after
@@ -1425,6 +1425,23 @@ spec:
                       type: string
                     metadata:
                       description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: 'Spec defines the desired characteristics of a
@@ -2081,6 +2098,23 @@ spec:
                               description: May contain labels and annotations that
                                 will be copied into the PVC when creating it. No other
                                 fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: The specification for the PersistentVolumeClaim.

--- a/deploy/crds/rocketmq.apache.org_consoles.yaml
+++ b/deploy/crds/rocketmq.apache.org_consoles.yaml
@@ -63,6 +63,23 @@ spec:
                     type: string
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      name:
+                        type: string
+                      namespace:
+                        type: string
                     type: object
                   spec:
                     description: Specification of the desired behavior of the Deployment.
@@ -205,6 +222,23 @@ spec:
                           metadata:
                             description: 'Standard object''s metadata. More info:
                               https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
                             type: object
                           spec:
                             description: 'Specification of the desired behavior of
@@ -6484,6 +6518,23 @@ spec:
                                                 the PVC when creating it. No other
                                                 fields are allowed and will be rejected
                                                 during validation.
+                                              properties:
+                                                annotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                finalizers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                labels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
                                               type: object
                                             spec:
                                               description: The specification for the

--- a/deploy/crds/rocketmq.apache.org_nameservices.yaml
+++ b/deploy/crds/rocketmq.apache.org_nameservices.yaml
@@ -46,9 +46,6 @@ spec:
           spec:
             description: NameServiceSpec defines the desired state of NameService
             properties:
-              ServiceAccountName:
-                description: ServiceAccountName
-                type: string
               affinity:
                 description: Affinity the pod's scheduling constraints
                 properties:
@@ -1239,6 +1236,9 @@ spec:
                         type: string
                     type: object
                 type: object
+              serviceAccountName:
+                description: ServiceAccountName
+                type: string
               size:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "operator-sdk generate k8s" to regenerate code after
@@ -1310,6 +1310,23 @@ spec:
                       type: string
                     metadata:
                       description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: 'Spec defines the desired characteristics of a

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,3 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,17 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
1. Fix the nameServerListStr empty bugs
Reassign the nameServerListStr variable even if the operator recreated.
Issue Ref. #123 

2. Regenerate some yaml files
Update some yaml files that automatically generated in `deploy` directory.