### PR TITLE
[ISSUE #178] add helm installation guides and support installing operator in namespaces other than default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ $ make deploy
 
 If you get error `rocketmq-operator/bin/controller-gen: No such file or directory`, please run `go version` to check the version of Golang, the main version should be 1.16. Then run `go mod tidy` before run `make deploy`.
 
+Or you can deploy the RocketMQ Operator by [helm](https://helm.sh/):
+
+```
+$ helm install rocketmq-operator charts/rocketmq-operator
+```
+
 3. Use command ```kubectl get pods``` to check the RocketMQ Operator deploy status like:
 
 ```

--- a/charts/rocketmq-operator/templates/NOTES.txt
+++ b/charts/rocketmq-operator/templates/NOTES.txt
@@ -1,0 +1,4 @@
+Your release is named {{ .Release.Name }}. To check the status of the release, run:
+
+  $ kubectl -n {{ .Release.Namespace }} get pods -l "name=rocketmq-operator"
+

--- a/charts/rocketmq-operator/templates/role_binding.yaml
+++ b/charts/rocketmq-operator/templates/role_binding.yaml
@@ -13,15 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  name: rocketmq-operator
-subjects:
-- kind: ServiceAccount
-  name: rocketmq-operator
-  namespace: default
+  name: {{ include "rocketmq-operator.fullname" . }}
+  labels:
+    {{- include "rocketmq-operator.labels" . | nindent 4 }}
 roleRef:
-  kind: ClusterRole
-  name: rocketmq-operator
   apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "rocketmq-operator.fullname" . }}
+subjects:
+  - name: {{ template "rocketmq-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount

--- a/charts/rocketmq-operator/templates/service_account.yaml
+++ b/charts/rocketmq-operator/templates/service_account.yaml
@@ -16,4 +16,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: rocketmq-operator
+  name: {{ template "rocketmq-operator.serviceAccountName" . }}


### PR DESCRIPTION
related to https://github.com/apache/rocketmq-operator/issues/178