### PR TITLE
[ISSUE #184 #192] support plain acl configration

### DIFF
--- a/example/rocketmq_v1alpha1_broker_cr.yaml
+++ b/example/rocketmq_v1alpha1_broker_cr.yaml
@@ -26,6 +26,24 @@ data:
     flushDiskType=ASYNC_FLUSH
     # set brokerRole to ASYNC_MASTER or SYNC_MASTER. DO NOT set to SLAVE because the replica instance will automatically be set!!!
     brokerRole=ASYNC_MASTER
+    # set aclEnable to true to enable ACL, and set plain_acl.yml to configure ACL
+    aclEnable=false
+
+  plain_acl.yml: |
+    globalWhiteRemoteAddresses:
+    accounts:
+      - accessKey: RocketMQ
+        secretKey: 12345678
+        whiteRemoteAddress:
+        admin: false
+        defaultTopicPerm: DENY
+        defaultGroupPerm: SUB
+        topicPerms:
+          - TopicTest=PUB
+        groupPerms:
+          # the group should convert to retry topic
+          - oms_consumer_group=DENY
+
 
 ---
 apiVersion: rocketmq.apache.org/v1alpha1
@@ -75,6 +93,13 @@ spec:
         items:
           - key: broker-common.conf
             path: broker-common.conf
+    # uncomment the following to enable ACL
+#    - name: plain-acl
+#      configMap:
+#        name: broker-config
+#        items:
+#          - key: plain_acl.yml
+#            path: plain_acl.yml
   # volumeClaimTemplates defines the storageClass
   volumeClaimTemplates:
     - metadata:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,6 +52,10 @@ const (
 	// BrokerConfigName is the name of mounted configuration file
 	BrokerConfigName = "broker-common.conf"
 
+	BrokerPlainAclConfigName = "plain_acl.yml"
+
+	BrokerPlainAclConfigPath = DataPath + "/rocketmq/broker/conf"
+
 	// UpdateBrokerConfig is update broker config command
 	UpdateBrokerConfig = "updateBrokerConfig"
 

--- a/pkg/controller/broker/broker_controller.go
+++ b/pkg/controller/broker/broker_controller.go
@@ -484,19 +484,7 @@ func (r *ReconcileBroker) getBrokerStatefulSet(broker *rocketmqv1alpha1.Broker, 
 							ContainerPort: cons.BrokerHighAvailabilityContainerPort,
 							Name:          cons.BrokerHighAvailabilityContainerPortName,
 						}},
-						VolumeMounts: []corev1.VolumeMount{{
-							MountPath: cons.LogMountPath,
-							Name:      broker.Spec.VolumeClaimTemplates[0].Name,
-							SubPath:   cons.LogSubPathName + getPathSuffix(broker, brokerGroupIndex, replicaIndex),
-						}, {
-							MountPath: cons.StoreMountPath,
-							Name:      broker.Spec.VolumeClaimTemplates[0].Name,
-							SubPath:   cons.StoreSubPathName + getPathSuffix(broker, brokerGroupIndex, replicaIndex),
-						}, {
-							MountPath: cons.BrokerConfigPath + "/" + cons.BrokerConfigName,
-							Name:      broker.Spec.Volumes[0].Name,
-							SubPath:   cons.BrokerConfigName,
-						}},
+						VolumeMounts: getVolumeMounts(broker, brokerGroupIndex, replicaIndex),
 					}},
 					Volumes:         getVolumes(broker),
 					SecurityContext: getPodSecurityContext(broker),
@@ -510,6 +498,30 @@ func (r *ReconcileBroker) getBrokerStatefulSet(broker *rocketmqv1alpha1.Broker, 
 
 	return dep
 
+}
+
+func getVolumeMounts(broker *rocketmqv1alpha1.Broker, brokerGroupIndex int, replicaIndex int) []corev1.VolumeMount {
+	mounts := []corev1.VolumeMount{{
+		MountPath: cons.LogMountPath,
+		Name:      broker.Spec.VolumeClaimTemplates[0].Name,
+		SubPath:   cons.LogSubPathName + getPathSuffix(broker, brokerGroupIndex, replicaIndex),
+	}, {
+		MountPath: cons.StoreMountPath,
+		Name:      broker.Spec.VolumeClaimTemplates[0].Name,
+		SubPath:   cons.StoreSubPathName + getPathSuffix(broker, brokerGroupIndex, replicaIndex),
+	}, {
+		MountPath: cons.BrokerConfigPath + "/" + cons.BrokerConfigName,
+		Name:      broker.Spec.Volumes[0].Name,
+		SubPath:   cons.BrokerConfigName,
+	}}
+	if len(broker.Spec.Volumes) > 1 && broker.Spec.Volumes[1].Name == "plain-acl" {
+		mounts = append(mounts, corev1.VolumeMount{
+			MountPath: cons.BrokerPlainAclConfigPath + "/" + cons.BrokerPlainAclConfigName,
+			Name:      broker.Spec.Volumes[1].Name,
+			SubPath:   cons.BrokerPlainAclConfigName,
+		})
+	}
+	return mounts
 }
 
 func getENV(broker *rocketmqv1alpha1.Broker, replicaIndex int, brokerGroupIndex int) []corev1.EnvVar {


### PR DESCRIPTION
## What is the purpose of the change

#192 #184 

## Brief changelog


## Verifying this change

1. apply follow yaml:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: broker-config
data:
  # BROKER_MEM sets the broker JVM, if set to "" then Xms = Xmx = max(min(1/2 ram, 1024MB), min(1/4 ram, 8GB))
  BROKER_MEM: " -Xms2g -Xmx2g -Xmn1g "
  broker-common.conf: |
    # brokerClusterName, brokerName, brokerId are automatically generated by the operator and do not set it manually!!!
    deleteWhen=04
    fileReservedTime=48
    flushDiskType=ASYNC_FLUSH
    # set brokerRole to ASYNC_MASTER or SYNC_MASTER. DO NOT set to SLAVE because the replica instance will automatically be set!!!
    brokerRole=ASYNC_MASTER
    # set aclEnable to true to enable ACL, and set plain_acl.yml to configure ACL
    aclEnable=true

  plain_acl.yml: |
    globalWhiteRemoteAddresses:
    accounts:
      - accessKey: RocketMQ
        secretKey: 12345678
        whiteRemoteAddress:
        admin: false
        defaultTopicPerm: DENY
        defaultGroupPerm: SUB
        topicPerms:
          - TopicTest=PUB
        groupPerms:
          # the group should convert to retry topic
          - oms_consumer_group=DENY

---
apiVersion: rocketmq.apache.org/v1alpha1
kind: Broker
metadata:
  # name of broker cluster
  name: broker
spec:
  clusterMode: CONTROLLER
  # size is the number of the broker cluster, each broker cluster contains a master broker and [replicaPerGroup] replica brokers.
  size: 1
  # nameServers is the [ip:port] list of name service
  nameServers: ""
  # replicaPerGroup is the number of each broker cluster
  replicaPerGroup: 1
  # brokerImage is the customized docker image repo of the RocketMQ broker
  brokerImage: ghcr.m.daocloud.io/ksmartdata/rocketmq-broker:v5.1.4
  # imagePullPolicy is the image pull policy
  imagePullPolicy: Always
  # resources describes the compute resource requirements and limits
  resources:
    requests:
      memory: "2048Mi"
      cpu: "250m"
    limits:
      memory: "12288Mi"
      cpu: "500m"
  # allowRestart defines whether allow pod restart
  allowRestart: true
  # storageMode can be EmptyDir, HostPath, StorageClass
  storageMode: StorageClass
  # hostPath is the local path to store data
  hostPath: /data/rocketmq/broker
  # scalePodName is [Broker name]-[broker group number]-master-0
  scalePodName: broker-0-0-0
  # env defines custom env, e.g. BROKER_MEM
  env:
    - name: BROKER_MEM
      valueFrom:
        configMapKeyRef:
          name: broker-config
          key: BROKER_MEM
  # volumes defines the broker.conf
  volumes:
    - name: broker-config
      configMap:
        name: broker-config
        items:
          - key: broker-common.conf
            path: broker-common.conf
    - name: plain-acl
      configMap:
        name: broker-config
        items:
          - key: plain_acl.yml
            path: plain_acl.yml

  # volumeClaimTemplates defines the storageClass
  volumeClaimTemplates:
    - metadata:
        name: broker-storage
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
---
apiVersion: rocketmq.apache.org/v1alpha1
kind: NameService
metadata:
  name: name-service
spec:
  # size is the the name service instance number of the name service cluster
  size: 1
  # nameServiceImage is the customized docker image repo of the RocketMQ name service
  nameServiceImage: ghcr.m.daocloud.io/ksmartdata/rocketmq-nameserver:v5.1.4
  # imagePullPolicy is the image pull policy
  imagePullPolicy: Always
  # hostNetwork can be true or false
  hostNetwork: false
  #  Set DNS policy for the pod.
  #  Defaults to "ClusterFirst".
  #  Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
  #  DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
  #  To have DNS options set along with hostNetwork, you have to specify DNS policy
  #  explicitly to 'ClusterFirstWithHostNet'.
  dnsPolicy: ClusterFirstWithHostNet
  # resources describes the compute resource requirements and limits
  resources:
    requests:
      memory: "512Mi"
      cpu: "250m"
    limits:
      memory: "1024Mi"
      cpu: "500m"
  # storageMode can be EmptyDir, HostPath, StorageClass
  storageMode: EmptyDir
  # hostPath is the local path to store data
  hostPath: /data/rocketmq/nameserver
  # volumeClaimTemplates defines the storageClass
  volumeClaimTemplates:
    - metadata:
        name: namesrv-storage
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
---
apiVersion: rocketmq.apache.org/v1alpha1
kind: Controller
metadata:
  # name of controller cluster
  name: controller
spec:
  # size is the number of controllers.
  size: 1
  # controllerImage is the customized docker image repo of the RocketMQ Controller
  controllerImage: ghcr.m.daocloud.io/ksmartdata/rocketmq-controller:v5.1.4
  # imagePullPolicy is the image pull policy
  imagePullPolicy: IfNotPresent
  # resources describes the compute resource requirements and limits
  resources:
    requests:
      memory: "0.5Gi"
    limits:
      memory: "2Gi"
  # storageMode can be EmptyDir, HostPath, StorageClass
  storageMode: StorageClass
  # hostPath is the local path to store data
  hostPath: /data/rocketmq/controller
  # volumeClaimTemplates defines the storageClass
  volumeClaimTemplates:
    - metadata:
        name: controller-storage
      spec:
        accessModes: [ "ReadWriteOnce" ]
        resources:
          requests:
            storage: 1Gi
```

2. execute command on nameserver
<img width="1440" alt="截屏2024-03-13 15 03 37" src="https://github.com/apache/rocketmq-operator/assets/32033618/b222f64a-ee21-4257-9e83-ff63dbb42a1c">

3. modify the tools.yaml
<img width="558" alt="截屏2024-03-13 15 06 04" src="https://github.com/apache/rocketmq-operator/assets/32033618/6f28260f-542c-4ced-99ff-54730a928250">

4. execute the same command on nameserver
<img width="1440" alt="截屏2024-03-13 15 06 40" src="https://github.com/apache/rocketmq-operator/assets/32033618/0b08df5c-aa7e-4967-ad34-47df5d9fee8f">

