### PR TITLE
[ISSUE #202 #159]when the broker uses hostNetwork, the IP registered by the broker to the nameserver is not the podIP

### DIFF
--- a/images/broker/alpine/brokerGenConfig.sh
+++ b/images/broker/alpine/brokerGenConfig.sh
@@ -27,7 +27,8 @@ function create_config() {
     echo "brokerClusterName=$BROKER_CLUSTER_NAME" >> $BROKER_CONFIG_FILE
     echo "brokerName=$BROKER_NAME" >> $BROKER_CONFIG_FILE
     echo "brokerId=$BROKER_ID" >> $BROKER_CONFIG_FILE
-    echo "brokerIP1=`hostname -i`" >> $BROKER_CONFIG_FILE
+
+    echo "brokerIP1=${POD_IP}" >> $BROKER_CONFIG_FILE
     if [ $BROKER_ID != 0 ]; then
         sed -i 's/brokerRole=.*/brokerRole=SLAVE/g' $BROKER_CONFIG_FILE
     fi

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -172,4 +172,7 @@ const (
 
 	// EnvControllerAddr is the container environment variable name of Controller address in Broker
 	EnvControllerAddr = "controllerAddr"
+
+	// EnvPodIp is the container environment variable name of pod ip.
+	EnvPodIp = "POD_IP"
 )

--- a/pkg/controller/broker/broker_controller.go
+++ b/pkg/controller/broker/broker_controller.go
@@ -525,6 +525,12 @@ func getENV(broker *rocketmqv1alpha1.Broker, replicaIndex int, brokerGroupIndex 
 	}, {
 		Name:  cons.EnvBrokerName,
 		Value: broker.Name + "-" + strconv.Itoa(brokerGroupIndex),
+	}, {
+		Name: cons.EnvPodIp,
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "status.podIP"},
+		},
 	}}
 	if broker.Spec.ClusterMode == "CONTROLLER" {
 		envs = append(envs, corev1.EnvVar{Name: cons.EnvEnableControllerMode, Value: "true"})


### PR DESCRIPTION
when the broker uses hostNetwork, the IP registered by the broker to the nameserver is not the podIP
related #202 #159 
## What is the purpose of the change

when the broker uses hostNetwork, the broker's IP returned by NameServer is the IP of the k8s node where the broker is located.

This is because the broker uses the cluster ip（or other ip） instead of its own pod ip when registering.

The root cause is that when using hostnetwork, the host's network is used, including /etc/hosts. When generating the `brokerIP1 `configuration project, use the `hostname -i` command in the `images/broker/alpine/brokerGenConfig.sh` to obtain the ip.

 <a href='https://github.com/apache/rocketmq-operator/blob/a8665716c8028741ec106814798e39fe07e6dcaa/images/broker/alpine/brokerGenConfig.sh#L30'>/images/broker/alpine/brokerGenConfig.sh#L30</a>
```
echo "brokerIP1=`hostname -i`" >> $BROKER_CONFIG_FILE
```

but in many cases this command does not correctly obtain the correct ip.
for exampels:
```
#/etc/hosts
127.0.0.1 localhost
127.0.1.1 master01
```
bash-4.4# hostname -i
127.0.1.1

 when use `127.0.1.1` to register, the nameserver will select the IP based on its own algorithm. Most of the time it is not the status.podIP of the pod we want:  https://github.com/apache/rocketmq/blob/2c898c9b31bf195174cf1e3a626a7c61f7576381/common/src/main/java/org/apache/rocketmq/common/utils/NetworkUtil.java#L91

```
#/etc/hosts
127.0.0.1 localhost
127.0.1.1 master01
10.6.178.178 master01
```
bash-4.4# hostname -i
127.0.1.1 10.6.178.178

check the log, it seems to be successful
![image](https://github.com/apache/rocketmq-operator/assets/3390414/ca077eca-da5b-4e68-982d-5890bdc8221e)

but when we used the mqadmin command to check the registered broker address, we found that this was not the case.
![image](https://github.com/apache/rocketmq-operator/assets/3390414/2a127dd2-0ae0-4008-937c-a94c3fcb5f46)

## Brief changelog
When setting up with hostNetwork option, we explicitly add an environment variable `HOST_NETWORK_POD_IP` on the pod. When obtaining `brokerIP1`, we obtain it from this environment variable and register it with the nameserver.

## Verifying this change

the log from the pod:
![image](https://github.com/apache/rocketmq-operator/assets/3390414/675c3b9c-25e9-4f3e-830e-e437cdf416ce)

the podIP: 
![image](https://github.com/apache/rocketmq-operator/assets/3390414/015b74e6-ebaf-4516-bece-0fdfa900fbdd)

![image](https://github.com/apache/rocketmq-operator/assets/3390414/ad3383a1-ba10-4c0a-959b-99cae749bd63)

use mqadmin see the broker address:
![image](https://github.com/apache/rocketmq-operator/assets/3390414/ffe169ea-ddfb-434e-8f6c-7c2e586f93b5)

**Please go through this checklist to help us incorporate your contribution quickly and easily.**

Notice: `It would be helpful if you could finish the following checklist (the last one is not necessary) before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq-operator/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check RBAC rights for Kubernetes roles.
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x] Run `make docker-build` to build docker image for operator, try your changes from Pod inside your Kubernetes cluster, **not just locally**. Also provide screenshots to show that the RocketMQ cluster is healthy after the changes. 
- [x] Before committing your changes, remember to run `make manifests` to make sure the CRD files are updated. 
- [x] Update documentation if necessary.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
