### PR TITLE
[ISSUE #229]when use cgroups v2, controller failed to start

### DIFF
--- a/images/controller/alpine/runserver-customize.sh
+++ b/images/controller/alpine/runserver-customize.sh
@@ -55,12 +55,30 @@ calculate_heap_sizes()
     case "`uname`" in
         Linux)
             system_memory_in_mb=`free -m| sed -n '2p' | awk '{print $2}'`
-            system_memory_in_mb_in_docker=$(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)/1024/1024))
+            if [ -f /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+              system_memory_in_mb_in_docker=$(($(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)/1024/1024))
+            elif [ -f /sys/fs/cgroup/memory.max ]; then
+                system_memory_in_mb_in_docker=$(($(cat /sys/fs/cgroup/memory.max)/1024/1024))
+            else
+                error_exit "Can not get memory, please check cgroup"
+            fi
             if [ $system_memory_in_mb_in_docker -lt $system_memory_in_mb ];then
               system_memory_in_mb=$system_memory_in_mb_in_docker
             fi
             system_cpu_cores=`egrep -c 'processor([[:space:]]+):.*' /proc/cpuinfo`
-            system_cpu_cores_in_docker=$(($(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)/$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)))
+            if [ -f /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then
+                system_cpu_cores_in_docker=$(($(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)/$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)))
+            elif [ -f /sys/fs/cgroup/cpu.max ]; then
+                QUOTA=$(cut -d ' ' -f 1 /sys/fs/cgroup/cpu.max)
+                PERIOD=$(cut -d ' ' -f 2 /sys/fs/cgroup/cpu.max)
+                if [ "$QUOTA" == "max" ]; then # no limit, see https://docs.kernel.org/admin-guide/cgroup-v2.html#cgroup-v2-cpu
+                  system_cpu_cores_in_docker=$system_cpu_cores
+                else
+                  system_cpu_cores_in_docker=$(($QUOTA/$PERIOD))
+                fi
+            else
+                error_exit "Can not get cpu, please check cgroup"
+            fi
             if [ $system_cpu_cores_in_docker -lt $system_cpu_cores -a $system_cpu_cores_in_docker -ne 0 ];then
               system_cpu_cores=$system_cpu_cores_in_docker
             fi


### PR DESCRIPTION
## What is the purpose of the change

fix bug #229

## Brief changelog
if no file /sys/fs/cgroup/memory/memory.limit_in_bytes
try file /sys/fs/cgroup/memory.max


## Verifying this change

kubectl get po |grep controller
controller-0                                                1/1     Running   0                 2m35s


**Please go through this checklist to help us incorporate your contribution quickly and easily.**

Notice: `It would be helpful if you could finish the following checklist (the last one is not necessary) before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq-operator/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check RBAC rights for Kubernetes roles.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. 
- [ ] Run `make docker-build` to build docker image for operator, try your changes from Pod inside your Kubernetes cluster, **not just locally**. Also provide screenshots to show that the RocketMQ cluster is healthy after the changes. 
- [ ] Before committing your changes, remember to run `make manifests` to make sure the CRD files are updated. 
- [ ] Update documentation if necessary.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
