### PR TITLE
[ISSUE #184 #192] expose acl configuration as configMap

### DIFF
--- a/example/rocketmq_v1alpha1_broker_cr.yaml
+++ b/example/rocketmq_v1alpha1_broker_cr.yaml
@@ -28,6 +28,39 @@ data:
     brokerRole=ASYNC_MASTER
 
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: broker-acl-config
+data:
+  plain_acl.yml: |
+    globalWhiteRemoteAddresses:
+      - 10.10.103.*
+      - 192.168.0.*
+
+    accounts:
+      - accessKey: RocketMQ
+        secretKey: 123456789
+        whiteRemoteAddress:
+        admin: false
+        defaultTopicPerm: DENY
+        defaultGroupPerm: SUB
+        topicPerms:
+          - topicA=DENY
+          - topicB=PUB|SUB
+          - topicC=SUB
+        groupPerms:
+          # the group should convert to retry topic
+          - groupA=DENY
+          - groupB=PUB|SUB
+          - groupC=SUB
+    
+      - accessKey: rocketmq2
+        secretKey: 123456789
+        whiteRemoteAddress: 192.168.1.*
+        # if it is admin, it could access all resources 
+        admin: true
+---
 apiVersion: rocketmq.apache.org/v1alpha1
 kind: Broker
 metadata:
@@ -75,6 +108,12 @@ spec:
         items:
           - key: broker-common.conf
             path: broker-common.conf
+    - name: broker-acl-config
+      configMap:
+        name: broker-acl-config
+        items:
+          - key: plain_acl.yml
+            path: plain_acl.yml
   # volumeClaimTemplates defines the storageClass
   volumeClaimTemplates:
     - metadata:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,8 +46,11 @@ const (
 	// SubscriptionGroupJsonDir is the directory of subscriptionGroup.json
 	SubscriptionGroupJsonDir = StoreConfigDir + "/subscriptionGroup.json"
 
-	// BrokerConfigDir is the directory of the mounted config file
+	// BrokerConfigPath is the directory of the mounted config file
 	BrokerConfigPath = DataPath + "/rocketmq/broker/conf"
+
+	// BrokerPlainAclConfigName is the name of mounted acl config file
+	BrokerPlainAclConfigName = "plain_acl.yml"
 
 	// BrokerConfigName is the name of mounted configuration file
 	BrokerConfigName = "broker-common.conf"


### PR DESCRIPTION
## What is the purpose of the change

[ISSUE #184 #192]
## Brief changelog
expose acl configuration as configMap

## Verifying this change
- add a acl configuration as configMap
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: broker-acl-config
data:
  plain_acl.yml: |
    globalWhiteRemoteAddresses:
      - 10.10.103.*
      - 192.168.0.*

    accounts:
      - accessKey: RocketMQ
        secretKey: 123456789 # |||
        whiteRemoteAddress:
        admin: false
        defaultTopicPerm: DENY
        defaultGroupPerm: SUB
        topicPerms:
          - topicA=DENY
          - topicB=PUB|SUB
          - topicC=SUB
        groupPerms:
          # the group should convert to retry topic
          - groupA=DENY
          - groupB=PUB|SUB
          - groupC=SUB
    
      - accessKey: rocketmq2
        secretKey: 123456789 # |||
        whiteRemoteAddress: 192.168.1.*
        # if it is admin, it could access all resources 
        admin: true
```

the brokers cr
```yaml
apiVersion: rocketmq.apache.org/v1alpha1
kind: Broker
metadata:
  annotations:
    input: '{"cluster":"mabing","namespace":"mcamel-system","name":"test0405","version":"v5.1.4","group_size":1,"replica_per_group":1,"broker_sync_mode":"SYNC_MASTER","root_name":"rocketmq","root_password":"MQ56/8wNi5u43S1VN859dA==","storage_class_name":"local-path","storage_capacity":"1Gi","service_type":1,"ports":[{"name":"nameservice","protocol":"TCP","port":9876,"target_port":9876}],"cpu_request":"0.1","cpu_limit":"1","memory_request":"0.1Gi","memory_limit":"1Gi","conf":"\n#
      brokerClusterName, brokerName, brokerId are automatically generated by the operator
      and do not set it manually!!!\ndeleteWhen=04\nfileReservedTime=48\nflushDiskType=ASYNC_FLUSH\n","name_service_cpu_request":"0.1","name_service_cpu_limit":"1","name_service_memory_request":"0.1Gi","name_service_memory_limit":"1Gi","name_service_replicas":1,"controller_cpu_request":"0.1","controller_cpu_limit":"1","controller_memory_request":"0.1Gi","controller_memory_limit":"1Gi","controller_replicas":1,"controller_storage_class_name":"local-path","controller_storage_capacity":"1Gi","is_open_console":true,"console_service_type":1,"console_cpu_request":"0.1","console_cpu_limit":"1","console_memory_request":"0.1Gi","console_memory_limit":"1Gi","service_monitor_interval":"30s","affinity":{}}'
  creationTimestamp: "2024-05-09T06:18:46Z"
  generation: 4
  name: test0405
  namespace: mcamel-system
  resourceVersion: "97739696"
  uid: 3bd0ee60-f45e-4ad2-b668-6f941d7e11c4
spec:
  affinity: {}
  allowRestart: true
  brokerImage: ghcr.m.daocloud.io/ksmartdata/rocketmq-broker:v5.1.4
  clusterMode: CONTROLLER
  env:
  - name: BROKER_MEM
    value: ' -Xms75m -Xmx768m -Xmn256m '
  hostPath: /data/rocketmq/broker
  imagePullPolicy: IfNotPresent
  replicaPerGroup: 1
  resources:
    limits:
      cpu: "1"
      memory: 1Gi
    requests:
      cpu: 100m
      memory: 107374182400m
  scalePodName: test0405-0-master-0
  size: 1
  storageMode: StorageClass
  volumeClaimTemplates:
  - metadata:
      name: broker-storage
    spec:
      accessModes:
      - ReadWriteOnce
      resources:
        requests:
          storage: 1Gi
      storageClassName: local-path
    status: {}
  volumes:
  - configMap:
      items:
      - key: broker-common.conf
        path: broker-common.conf
      name: test0405-broker-cm
    name: broker-config
  - configMap:
      items:
      - key: plain_acl.yml
        path: plain_acl.yml
      name: broker-acl-config
    name: broker-acl-config
status:
  nodes:
  - test0405-0-1-0
  - test0405-0-0-0
  size: 1
```

the /root/rocketmq/broker/conf/plain_acl.yml in the pod
![image](https://github.com/apache/rocketmq-operator/assets/3390414/dc8307b6-e39f-4d6e-b550-2fb49490371d)

**Please go through this checklist to help us incorporate your contribution quickly and easily.**

Notice: `It would be helpful if you could finish the following checklist (the last one is not necessary) before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq-operator/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Check RBAC rights for Kubernetes roles.
- [ ] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. 
- [ ] Run `make docker-build` to build docker image for operator, try your changes from Pod inside your Kubernetes cluster, **not just locally**. Also provide screenshots to show that the RocketMQ cluster is healthy after the changes. 
- [ ] Before committing your changes, remember to run `make manifests` to make sure the CRD files are updated. 
- [ ] Update documentation if necessary.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
